### PR TITLE
Add crash demo starter stack

### DIFF
--- a/game-v2/.github/workflows/deploy.yml
+++ b/game-v2/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Sync files
+        uses: burnett01/rsync-deployments@6.0.0
+        with:
+          switches: -avzr --delete
+          path: ./
+          remote_path: /srv/game-v2/
+          remote_host: ${{ secrets.SSH_HOST }}
+          remote_user: ${{ secrets.SSH_USER }}
+          remote_key: ${{ secrets.SSH_KEY }}
+      - name: Remote build & restart
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          script: |
+            bash /srv/game-v2/scripts/deploy.sh

--- a/game-v2/.gitignore
+++ b/game-v2/.gitignore
@@ -1,0 +1,20 @@
+# Node
+node_modules/
+
+# Vite build output
+client/dist/
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Env
+.env
+server/.env

--- a/game-v2/client/index.html
+++ b/game-v2/client/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Clash Demo v2</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/game-v2/client/package.json
+++ b/game-v2/client/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "game-v2-client",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -p . && vite build",
+    "preview": "vite preview --host 0.0.0.0 --port 5173"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.4",
+    "@types/react-dom": "^18.3.0",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.8"
+  }
+}

--- a/game-v2/client/src/App.tsx
+++ b/game-v2/client/src/App.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from "react";
+import { LeftPanel } from "./components/LeftPanel";
+import { Arena } from "./components/Arena";
+import { InvestorPanel } from "./components/InvestorPanel";
+import { RoundTotals } from "./components/RoundTotals";
+
+const WS_PATH = (location.protocol === "https:" ? "wss://" : "ws://") + location.host + "/ws";
+
+export default function App(){
+  const [wsOnline, setWsOnline] = useState(false);
+  const [mode, setMode] = useState("CRASH");
+  const [timeLeft, setTimeLeft] = useState<number|null>(null);
+  const [mult, setMult] = useState(1);
+  const [rounds, setRounds] = useState(0);
+
+  useEffect(() => {
+    let ws: WebSocket | null = null;
+    let retry = 0;
+    const connect = () => {
+      ws = new WebSocket(WS_PATH);
+      ws.onopen = () => { setWsOnline(true); retry = 0; };
+      ws.onclose = () => { setWsOnline(false); setTimeout(connect, Math.min(5000, 500*(++retry))); };
+      ws.onmessage = (ev) => {
+        const msg = JSON.parse(ev.data);
+        if(msg.type === "state"){
+          setMode(msg.state.mode);
+          setTimeLeft(msg.state.timeLeftSec);
+          setMult(msg.state.crash.liveMultiplier);
+          setRounds(msg.state.investor.rounds);
+        }
+      };
+    };
+    connect();
+    return () => { ws?.close(); };
+  }, []);
+
+  return (
+    <div className="app">
+      <LeftPanel wsOnline={wsOnline} stateMode={mode} timeLeft={timeLeft} />
+      <Arena multiplier={mult} />
+      <div className="card" style={{gridColumn:"3 / 4"}}>
+        <InvestorPanel rtp={97.0} rounds={rounds} />
+        <div className="card" style={{marginTop:12}}>
+          <RoundTotals />
+        </div>
+        <div className="card" style={{marginTop:12}}>
+          <h3>Events</h3>
+          <div className="small">Live feed will appear here (kept minimal for demo).</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/game-v2/client/src/components/Arena.tsx
+++ b/game-v2/client/src/components/Arena.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+export const Arena: React.FC<{ multiplier: number }>=({ multiplier })=>{
+  // Move rocket diagonally based on multiplier (demo only)
+  const x = Math.min(100, (multiplier - 1) * 18);
+  const y = Math.min(100, (multiplier - 1) * 10);
+  return (
+    <div className="card" style={{gridColumn:"2 / 3"}}>
+      <h3>Dual Crash · Arena</h3>
+      <div className="canvasWrap">
+        <img className="rocket" src="data:image/svg+xml;utf8,<?xml version='1.0' encoding='UTF-8'?><svg xmlns='http://www.w3.org/2000/svg' width='40' height='40' viewBox='0 0 64 64'><path fill='%23ff598a' d='M34 4c12 4 17 24 17 24l-9 9s-20-5-24-17S22 0 34 4z'/><circle cx='44' cy='24' r='5' fill='%23c7f7ff'/><path fill='%2380e1c1' d='M12 52l6-6l10 2l-8 8z'/></svg>" style={{ transform:`translate(${x*6}px,-${y*4}px)` }} />
+      </div>
+    </div>
+  );
+};

--- a/game-v2/client/src/components/InvestorPanel.tsx
+++ b/game-v2/client/src/components/InvestorPanel.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+export const InvestorPanel: React.FC<{ rtp:number; rounds:number }>=({ rtp, rounds })=> (
+  <div className="card">
+    <h3>Investor panel</h3>
+    <div className="row" style={{gap:8,marginBottom:6}}>
+      <div className="badge">Bankroll 100000 €</div>
+      <div className="badge">Jackpot 0 €</div>
+      <div className="badge">Liability: 0 €</div>
+    </div>
+    <div className="row" style={{gap:8}}>
+      <div className="badge">RTP (avg): {rtp.toFixed(2)}%</div>
+      <div className="badge">Rounds: {rounds}</div>
+    </div>
+  </div>
+);

--- a/game-v2/client/src/components/LeftPanel.tsx
+++ b/game-v2/client/src/components/LeftPanel.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { Badge, Field } from "./UiBits";
+
+type Props = {
+  wsOnline: boolean;
+  stateMode: string;
+  timeLeft: number | null;
+};
+
+export const LeftPanel: React.FC<Props> = ({ wsOnline, stateMode, timeLeft }) => {
+  return (
+    <div className="card">
+      <div className="row" style={{justifyContent:"space-between"}}>
+        <h3>Clash Demo</h3>
+        <div className="row" style={{gap:8}}>
+          <Badge>{wsOnline ? "WS online" : "WS offline"}</Badge>
+          <Badge>state→</Badge>
+        </div>
+      </div>
+
+      <div className="card" style={{marginTop:12}}>
+        <div className="row" style={{justifyContent:"space-between",marginBottom:6}}>
+          <div className="small">Time left</div>
+          <div className="small">Next</div>
+        </div>
+        <div className="row" style={{justifyContent:"space-between",alignItems:"center"}}>
+          <div className="kpi" style={{fontSize:22}}>{timeLeft ?? "—"}</div>
+          <div className="kpi" style={{fontSize:22}}>{stateMode}</div>
+        </div>
+        <div className="row" style={{gap:8, marginTop:12}}>
+          <button className="btn">Crash</button>
+          <button className="btn">Winner</button>
+          <button className="btn prim">Start</button>
+          <button className="btn danger">Reset</button>
+          <button className="btn">Round →</button>
+        </div>
+      </div>
+
+      <div className="card" style={{marginTop:12}}>
+        <h3>Wallet & Mode</h3>
+        <div className="row" style={{justifyContent:"space-between"}}>
+          <div>
+            <div className="small">Balance</div>
+            <div className="kpi">$741.77</div>
+          </div>
+          <div className="col" style={{alignItems:"flex-end"}}>
+            <div className="small">Add $</div>
+            <div className="row" style={{gap:8}}>
+              <button className="btn">+50</button>
+              <button className="btn">+100</button>
+              <button className="btn">+250</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="card" style={{marginTop:12}}>
+        <h3>Main bet</h3>
+        <Field label="Amount">
+          <input className="input" placeholder="50" />
+        </Field>
+        <div className="row" style={{gap:8, marginTop:10}}>
+          <button className="btn">Side A</button>
+          <button className="btn">Side B</button>
+        </div>
+        <div className="row" style={{gap:8, marginTop:10}}>
+          <button className="btn prim">Bet</button>
+          <button className="btn danger">Cashout</button>
+        </div>
+      </div>
+
+      <div className="card" style={{marginTop:12}}>
+        <h3>Micro-bets</h3>
+        <div className="row" style={{gap:8, marginBottom:8}}>
+          <button className="btn">A</button>
+          <button className="btn">B</button>
+          <button className="btn">Speed</button>
+          <button className="btn">Defense</button>
+        </div>
+        <div className="row" style={{gap:8}}>
+          <button className="btn">+1</button>
+          <button className="btn">+5</button>
+          <button className="btn">+10</button>
+          <button className="btn">+25</button>
+        </div>
+        <div className="row" style={{gap:30,marginTop:10}}>
+          <div className="small">A Speed 0</div>
+          <div className="small">B Speed 0</div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/game-v2/client/src/components/RoundTotals.tsx
+++ b/game-v2/client/src/components/RoundTotals.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+export const RoundTotals: React.FC = () => (
+  <div className="card">
+    <h3>Round totals</h3>
+    <div className="kv"><div>Round</div><div>—</div></div>
+    <div className="kv"><div>Mode</div><div>CRASH</div></div>
+    <div className="kv"><div>Main bets</div><div>$0.00</div></div>
+    <div className="kv"><div>Micro bets</div><div>$0.00</div></div>
+    <div className="kv"><div>Burned</div><div>$0.00</div></div>
+    <div className="kv"><div>Payouts</div><div>$0.00</div></div>
+    <div className="kv"><div>Rake (2%)</div><div>$0.00</div></div>
+    <div className="kv"><div>Operator Δ</div><div>$0.00</div></div>
+  </div>
+);

--- a/game-v2/client/src/components/UiBits.tsx
+++ b/game-v2/client/src/components/UiBits.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+export const Badge: React.FC<React.PropsWithChildren<{ tone?: "ok"|"danger" }>> = ({ tone, children }) => (
+  <span className="badge" style={ tone==="ok" ? { borderColor:"#2b8", color:"#bff" } : tone==="danger" ? { borderColor:"#b66", color:"#ffd6d9" } : {} }>
+    {children}
+  </span>
+);
+
+export const Field: React.FC<{ label: string; right?: React.ReactNode; children?: React.ReactNode }>=({label,right,children})=> (
+  <div className="col">
+    <div className="row" style={{justifyContent:"space-between"}}>
+      <div className="small">{label}</div>
+      {right && <div className="small">{right}</div>}
+    </div>
+    {children}
+  </div>
+);

--- a/game-v2/client/src/main.tsx
+++ b/game-v2/client/src/main.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+import "./styles.css";
+
+createRoot(document.getElementById("root")!).render(<App/>);

--- a/game-v2/client/src/styles.css
+++ b/game-v2/client/src/styles.css
@@ -1,0 +1,42 @@
+:root {
+  --bg: #0f1a25;
+  --panel: #111f2c;
+  --panel-2: #0d1823;
+  --muted: #7f8ea3;
+  --text: #eef5ff;
+  --accent: #2aa3ff;
+  --danger: #b54b55;
+  --ok: #32c08d;
+  --shadow: 0 6px 20px rgba(0,0,0,.35);
+}
+*{box-sizing:border-box}
+html,body,#root{height:100%}
+body{margin:0;background:radial-gradient(100% 100% at 0% 0%, #0b1420, var(--bg));color:var(--text);font:14px/1.35 system-ui, Segoe UI, Inter, Arial}
+
+.app{display:grid;gap:16px;height:100%;padding:16px;grid-template-columns:320px 1fr 360px}
+.card{background:linear-gradient(180deg,var(--panel),var(--panel-2));border-radius:14px;padding:16px;box-shadow:var(--shadow);border:1px solid rgba(255,255,255,.04)}
+.card h3{margin:0 0 10px 0;font-size:14px;color:#a8bed8;letter-spacing:.2px}
+.badge{display:inline-flex;align-items:center;gap:6px;padding:4px 8px;border-radius:999px;background:rgba(255,255,255,.06);color:#c9d8ea;border:1px solid rgba(255,255,255,.08);font-size:12px}
+.row{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+.col{display:flex;flex-direction:column;gap:10px}
+.kpi{font-weight:700}
+.btn{background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.08);color:#e9f2ff;padding:8px 12px;border-radius:10px;cursor:pointer}
+.btn:hover{filter:brightness(1.1)}
+.btn.prim{background:linear-gradient(180deg,#1a8fff,#0d6efd)}
+.btn.danger{background:linear-gradient(180deg,#cd5966,#a83c47)}
+.input{background:#0b1722;border:1px solid rgba(255,255,255,.08);border-radius:10px;color:var(--text);padding:8px 10px}
+.small{font-size:12px;color:var(--muted)}
+.table{width:100%;border-collapse:separate;border-spacing:0 6px}
+.table td{padding:6px 0;border-bottom:1px dashed rgba(255,255,255,.08)}
+.center{display:grid;place-items:center}
+
+/* Arena */
+.canvasWrap{height:520px;border-radius:14px;background:#0b1420;border:1px solid rgba(255,255,255,.06);box-shadow:inset 0 0 0 1px rgba(255,255,255,.02);position:relative;overflow:hidden}
+.rocket{position:absolute;left:20px;bottom:20px;transition:transform .08s linear}
+
+/* Right side */
+.kv{display:grid;grid-template-columns:1fr auto;gap:8px;margin:6px 0}
+.kv div:last-child{text-align:right;font-weight:700}
+
+/* Responsive fallback */
+@media (max-width:1200px){.app{grid-template-columns:1fr;grid-auto-rows:min-content}}

--- a/game-v2/client/tsconfig.json
+++ b/game-v2/client/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["vite/client"],
+    "outDir": "dist-types"
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/game-v2/client/vite.config.ts
+++ b/game-v2/client/vite.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: { host: true },
+  build: { outDir: "dist" }
+});

--- a/game-v2/nginx/game-v2.conf
+++ b/game-v2/nginx/game-v2.conf
@@ -1,0 +1,26 @@
+# Replace your.domain with real host
+server {
+    listen 80;
+    server_name your.domain;
+
+    root /var/www/game-v2;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # WebSocket to Fastify server
+    location /ws {
+        proxy_pass http://127.0.0.1:8080/ws;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+    }
+
+    location /api/ {
+        proxy_pass http://127.0.0.1:8080/api/;
+        proxy_set_header Host $host;
+    }
+}

--- a/game-v2/scripts/deploy.sh
+++ b/game-v2/scripts/deploy.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=/srv/game-v2
+cd "$ROOT"
+
+# Server
+pushd server
+npm ci
+npm run build
+popd
+
+# Client
+pushd client
+npm ci
+npm run build
+rsync -a --delete dist/ /var/www/game-v2/
+popd
+
+# Nginx (first time: link the site)
+[ -f /etc/nginx/sites-available/game-v2.conf ] || cp "$ROOT/nginx/game-v2.conf" /etc/nginx/sites-available/game-v2.conf
+ln -sf /etc/nginx/sites-available/game-v2.conf /etc/nginx/sites-enabled/game-v2.conf
+nginx -t && systemctl reload nginx
+
+# Systemd
+[ -f /etc/systemd/system/game-v2.service ] || cp "$ROOT/systemd/game-v2.service" /etc/systemd/system/game-v2.service
+systemctl daemon-reload
+systemctl enable --now game-v2.service
+systemctl status --no-pager game-v2.service || true

--- a/game-v2/server/package.json
+++ b/game-v2/server/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "game-v2-server",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "dev": "node --env-file=.env --watch --enable-source-maps dist/index.js",
+    "build": "tsc -p .",
+    "start": "node --env-file=.env --enable-source-maps dist/index.js"
+  },
+  "dependencies": {
+    "fastify": "^4.27.2",
+    "fastify-websocket": "^7.1.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.8.1",
+    "typescript": "^5.6.3"
+  }
+}

--- a/game-v2/server/src/config.ts
+++ b/game-v2/server/src/config.ts
@@ -1,0 +1,12 @@
+import type { ServerConfig } from "./types";
+
+export const config: ServerConfig = {
+  host: process.env.HOST ?? "0.0.0.0",
+  port: Number(process.env.PORT ?? 8080),
+  publicUrl: process.env.PUBLIC_URL,
+};
+
+export const TICK_MS = 100; // smooth multiplier
+export const ROUND_MS = 10_000; // 10s round for demo
+export const BREAK_MS = 3_000; // pause between rounds
+export const RAKE_PCT = 0.02; // 2% for demo UI

--- a/game-v2/server/src/gameEngine.ts
+++ b/game-v2/server/src/gameEngine.ts
@@ -1,0 +1,121 @@
+import { BREAK_MS, RAKE_PCT, ROUND_MS, TICK_MS } from "./config";
+import type { GameState, WsOut } from "./types";
+
+export class GameEngine {
+  private state: GameState;
+  private timer?: NodeJS.Timeout;
+  private between?: NodeJS.Timeout;
+  private tickers = new Set<(msg: WsOut) => void>();
+
+  constructor() {
+    this.state = this.initialState();
+  }
+
+  private initialState(): GameState {
+    return {
+      mode: "CRASH",
+      round: 0,
+      timeLeftSec: null,
+      next: "CRASH",
+      crash: {
+        liveMultiplier: 1.0,
+        crashed: false,
+      },
+      investor: {
+        bankroll: 100000,
+        jackpot: 0,
+        liability: 0,
+        rtpAvg: 0,
+        rounds: 0,
+      },
+      totals: {
+        mainBets: 0,
+        microBets: 0,
+        burned: 0,
+        payouts: 0,
+        rake: 0,
+        operator: 0,
+      },
+      flags: { riskGuard: false },
+    };
+  }
+
+  subscribe(send: (msg: WsOut) => void) {
+    this.tickers.add(send);
+    send({ type: "hello", now: Date.now() });
+    send({ type: "state", state: this.state });
+    return () => this.tickers.delete(send);
+  }
+
+  private broadcast(msg: WsOut) {
+    for (const fn of this.tickers) fn(msg);
+  }
+
+  startLoop() {
+    if (this.timer || this.between) return; // already running
+    this.nextRound();
+  }
+
+  private nextRound() {
+    this.state.round += 1;
+    this.state.timeLeftSec = Math.ceil(ROUND_MS / 1000);
+    this.state.crash.liveMultiplier = 1.0;
+    this.state.crash.crashed = false;
+    this.state.investor.rounds += 1;
+
+    const start = Date.now();
+
+    this.broadcast({
+      type: "event",
+      message: `Round #${this.state.round} start` ,
+      ts: Date.now(),
+    });
+    this.broadcast({ type: "state", state: this.state });
+
+    this.timer = setInterval(() => {
+      const elapsed = Date.now() - start;
+
+      // smooth expo-ish growth for demo
+      const growth = 1 + Math.pow(elapsed / ROUND_MS, 1.5) * 3.5;
+      this.state.crash.liveMultiplier = Math.max(1, Number(growth.toFixed(2)));
+
+      // fake crash chance increases with time
+      const p = elapsed / ROUND_MS;
+      const crashNow = Math.random() < p * 0.04; // gentle
+
+      this.state.timeLeftSec = Math.max(0, Math.ceil((ROUND_MS - elapsed) / 1000));
+
+      if (crashNow || elapsed >= ROUND_MS) {
+        this.state.crash.crashed = true;
+        this.state.timeLeftSec = 0;
+
+        // update simple financials for UI (demo numbers)
+        const rake = Math.round(this.state.totals.mainBets * RAKE_PCT);
+        this.state.totals.rake += rake;
+        this.state.totals.operator += rake;
+        this.broadcast({ type: "state", state: this.state });
+
+        clearInterval(this.timer!);
+        this.timer = undefined;
+
+        this.broadcast({
+          type: "event",
+          message: `Round #${this.state.round} crashed at x${this.state.crash.liveMultiplier.toFixed(2)}`,
+          ts: Date.now(),
+        });
+
+        this.between = setTimeout(() => {
+          this.between = undefined;
+          this.nextRound();
+        }, BREAK_MS);
+      } else {
+        // live tick
+        this.broadcast({ type: "state", state: this.state });
+      }
+    }, TICK_MS);
+  }
+
+  snapshot(): GameState {
+    return this.state;
+  }
+}

--- a/game-v2/server/src/index.ts
+++ b/game-v2/server/src/index.ts
@@ -1,0 +1,27 @@
+import Fastify from "fastify";
+import websocket from "fastify-websocket";
+import { config } from "./config.js";
+import { GameEngine } from "./gameEngine.js";
+import type { WsOut } from "./types.js";
+
+const app = Fastify({ logger: true });
+app.register(websocket);
+
+const engine = new GameEngine();
+engine.startLoop();
+
+app.get("/health", async () => ({ ok: true, ts: Date.now() }));
+app.get("/api/state", async () => engine.snapshot());
+
+app.get("/ws", { websocket: true }, (conn, req) => {
+  const send = (msg: WsOut) => {
+    try { conn.socket.send(JSON.stringify(msg)); } catch { /* client gone */ }
+  };
+
+  const unsub = engine.subscribe(send);
+  conn.socket.on("close", () => unsub());
+});
+
+app.listen({ host: config.host, port: config.port }).then((addr) => {
+  app.log.info({ addr, publicUrl: config.publicUrl }, "server started");
+});

--- a/game-v2/server/src/types.ts
+++ b/game-v2/server/src/types.ts
@@ -1,0 +1,43 @@
+export type ServerConfig = {
+  host: string;
+  port: number;
+  publicUrl?: string;
+};
+
+export type Ticker = ReturnType<typeof setInterval>;
+
+export type WsOut =
+  | { type: "hello"; now: number }
+  | { type: "state"; state: GameState }
+  | { type: "event"; message: string; ts: number };
+
+export type GameMode = "CRASH"; // room for FIGHTS later
+
+export type GameState = {
+  mode: GameMode;
+  round: number;
+  timeLeftSec: number | null; // null when idle
+  next: GameMode;
+  crash: {
+    liveMultiplier: number; // grows over time
+    crashed: boolean;
+  };
+  investor: {
+    bankroll: number;
+    jackpot: number;
+    liability: number;
+    rtpAvg: number;
+    rounds: number;
+  };
+  totals: {
+    mainBets: number;
+    microBets: number;
+    burned: number;
+    payouts: number;
+    rake: number;
+    operator: number;
+  };
+  flags: {
+    riskGuard: boolean;
+  };
+};

--- a/game-v2/server/tsconfig.json
+++ b/game-v2/server/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
+}

--- a/game-v2/systemd/game-v2.service
+++ b/game-v2/systemd/game-v2.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Clash Demo v2 (Fastify + WS)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=www-data
+WorkingDirectory=/srv/game-v2/server
+Environment=NODE_ENV=production
+Environment=HOST=127.0.0.1
+Environment=PORT=8080
+ExecStart=/usr/bin/node /srv/game-v2/server/dist/index.js
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add Fastify WebSocket server with crash game loop and health endpoints
- scaffold React + Vite client UI that mirrors the crash dashboard layout
- include deployment tooling (systemd unit, nginx config, deploy script, and CI workflow)

## Testing
- npm install *(fails: registry returns 403 when fetching packages in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3a4bbcaa48320b5d3f7e0155a3ee5